### PR TITLE
Locale component with default locale as browser locale

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,8 +16,11 @@ function loadLocaleMessages () {
   return messages
 }
 
+function getBrowserLocale () {
+  return navigator.language.split('-')[0]
+}
 export default new VueI18n({
-  locale: process.env.VUE_APP_I18N_LOCALE || 'en',
+  locale: getBrowserLocale() || process.env.VUE_APP_I18N_LOCALE || 'en',
   fallbackLocale: process.env.VUE_APP_I18N_FALLBACK_LOCALE || 'en',
   messages: loadLocaleMessages()
 })

--- a/src/patterns/Locale/Locale.stories.mdx
+++ b/src/patterns/Locale/Locale.stories.mdx
@@ -1,0 +1,27 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks'
+import { figmaConfig } from '../../utils/helpers'
+
+import Locale from '@/patterns/Locale/Locale'
+
+<Meta title="Patterns/Locale" />
+
+# Locale
+
+<Preview>
+  <Story name="Default">{{
+      data () {
+      return{
+        configs:{
+          locales:{
+          English:'en',
+          Hindu: 'hi',
+          },
+          defaultLang: 'en'
+        }
+      }
+    },
+  components: {Locale},
+  template: `
+    <Locale :langs="configs"></Locale>`
+}}</Story>
+</Preview>

--- a/src/patterns/Locale/Locale.vue
+++ b/src/patterns/Locale/Locale.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="vocab locale">
     <!-- TODO -->
+    Languages available
+    <div class="control has-icons-left">
+
+      <div class="select">
+        <select v-model="selected" @change="setLang">
+          <option disabled>select</option>
+          <option v-for="(langCode,index) in langs.locales" v-bind:value="langCode" :key="index">
+            {{index}} - {{langCode}}
+          </option>
+        </select>
+      </div>
+      <div class="icon is-small is-left">
+        <!-- TODO Add icons here -->
+      </div>
+    </div>
   </div>
 </template>
 
@@ -12,6 +27,21 @@
    * switch between locales using this component.
    */
   export default {
-    name: 'Locale'
+    name: 'Locale',
+    props: {
+      langs: {
+        type: Object
+      }
+    },
+    data: function () {
+      return {
+        selected: this.langs.defaultLang || navigator.language.split('-')[0] || 'en'
+      }
+    },
+    methods: {
+      setLang: function () {
+        this.$root.$i18n.locale = this.selected
+      }
+    }
   }
 </script>


### PR DESCRIPTION
## Fixes
Fixes  #226

## Description
Componentizing the cc-vocabulary locale into a vue component in vue-vocabulary.
The component is used to switch the language of page . The option displayed in the component currently shows the language and the language's locale.(e.g: English-en)

# How to use
call the component as <Locale></Locale> by passing props of type Object..
## props
It is a configuration object containing two keys: locales and defaultLang
### Locales
Holds the various languages to be used alongside their locales
### defaultLang(optional)
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->
![local](https://user-images.githubusercontent.com/64994841/84074141-ff010900-a9c9-11ea-96dd-8ecb2c801492.png)


## Checklist
<!-- Replace the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
